### PR TITLE
Version 1.4:  Adding option for the user to provide magnetic field and density models

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,10 +2,7 @@
     "creators": [
         {
             "orcid": "0000-0002-9552-8822",
-            "affiliation": [
-                "https://ror.org/02eptjh02",
-                "https://ror.org/051sx6d27"
-            ],
+            "affiliation": "https://ror.org/017zz7s54",
             "name": "Louis, Corentin K."
         },
         {
@@ -16,18 +13,18 @@
         {
             "name": "Cecconi, Baptiste",
             "orcid": "0000-0001-7915-5571",
-            "affiliation": "https://ror.org/02eptjh02"
+            "affiliation": "https://ror.org/017zz7s54"
         },
         {
             "name": "Zarka, Philippe",
             "orcid": "0000-0003-1672-9878",
-            "affiliation": "https://ror.org/02eptjh02"
+            "affiliation": "https://ror.org/017zz7s54"
         },
         {
             "name": "Lamy, Laurent",
             "orcid": "0000-0002-8428-1369",
             "affiliation": {
-                "https://ror.org/02eptjh02":
+                "https://ror.org/017zz7s54":
                 "https://ror.org/00ssy9q55"
             }
         },
@@ -39,7 +36,7 @@
         {
             "name": "Loh, Alan",
             "orcid": "0000-0002-4698-9542",
-            "affiliation": "https://ror.org/02eptjh02"
+            "affiliation": "https://ror.org/017zz7s54"
         }
     ],
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,10 +2,10 @@
     "creators": [
         {
             "orcid": "0000-0002-9552-8822",
-            "affiliation": {
-                "https://ror.org/02eptjh02":
+            "affiliation": [
+                "https://ror.org/02eptjh02",
                 "https://ror.org/051sx6d27"
-            },
+            ],
             "name": "Louis, Corentin K."
         },
         {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Exoplanetary and Planetary Radio Emission Simulator (ExPRES) V1.3.0
+# Exoplanetary and Planetary Radio Emission Simulator (ExPRES) V1.4.0
 
 <a href="http://ascl.net/1902.009"><img src="https://img.shields.io/badge/ascl-1902.009-blue.svg?colorB=262255" alt="ascl:1902.009" /></a>
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4280546.svg)](https://doi.org/10.5281/zenodo.4280546)

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,15 +1,30 @@
 # Version History
 
-## Latest Release - 1.3.0 (2023)
+## Latest Release - 1.4.0 (2025)
+Contributors: C. Louis, B. Cecconi
+
+Change Log for version 1.4.0:
+- Add the possibility for users to provide magnetic field and density models
+- The option to have sources located on magnetic field lines with the M Shell is now available for all target
+- Distance values units can either be in physical units (km) or in Planetary Radius (it needs to be consistent all through the config file).
+Physical units (km) are recommanded. Planetary Radius units can still be used, except in the two following cases:
+     - If OBSERVER TYPE == Pre-Defined
+     - If [BODY][PHASE] == "auto" (for body ≠ central body)
+- Creation of codemeta.json file
+
+Related Publications:
+- Judy Chebly, Antoine Strugarek, Corentin K. Louis, "", to be submitted to Astronomy & Astrophysics
+
+## Version 1.3.0 (2023)
 Contributors: C. Louis, B. Cecconi
 
 Change Log for version 1.3.0:
 - Add the wave propagation mode (LO or RX) as an (optional) input. Default value is RX.
 
 Related Publication: 
-- Philippe Zarka, Corentin K. Louis, Jiale Zhang, Hui Tian, Julien Morin and Yang Gao, "Location and energy of electrons producing the radio bursts from AD Leo observed by FAST in December 2021", submitted to Astronomy & Astrophysics
+- Philippe Zarka, Corentin K. Louis, Jiale Zhang, Hui Tian, Julien Morin and Yang Gao (2025), "Location and energy of electrons producing the radio bursts from AD Leo observed by FAST in December 2021", Astronomy & Astrophysics, 695, A95 (2025). https://doi.org/10.1051/0004-6361/202450950
 
-## Version  1.2.0 (2023)
+## Version 1.2.0 (2023)
 
 Contributors: C. Louis, B. Cecconi
 
@@ -24,7 +39,7 @@ Related Publication:
 - Hue, V., Gladstone, G. R., Louis, C. K., Greathouse, T. K., Bonfond, B., Szalay, J. R., et al. (2023), "The Io, Europa, and Ganymede auroral footprints at Jupiter in the ultraviolet: Positions and equatorial lead angles", Journal of Geophysical Research: Space Physics, 128, e2023JA031363. https://doi.org/10.1029/2023JA031363
 
 
-## Version  1.1.0 (2020)
+## Version 1.1.0 (2020)
 
 Contributors: C. Louis, B. Cecconi
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -13,7 +13,7 @@ Physical units (km) are recommanded. Planetary Radius units can still be used, e
 - Creation of codemeta.json file
 
 Related Publications:
-- Judy Chebly, Antoine Strugarek, Corentin K. Louis, "", to be submitted to Astronomy & Astrophysics
+- Judy Chebly, Antoine Strugarek, Corentin K. Louis, Julian D. Alvarado Gomez, Philippe Zarka, "Assessing SPI-induced radio emission using 3D MHD simulations of stellar winds", to be submitted to Astronomy & Astrophysics
 
 ## Version 1.3.0 (2023)
 Contributors: C. Louis, B. Cecconi

--- a/codemeta.json
+++ b/codemeta.json
@@ -6,20 +6,20 @@
     "dateCreated": "2006-09-01",
     "datePublished": "2019-01-08",
     "dateModified": "2023-12-21",
-    "downloadUrl": "https://github.com/maserlib/ExPRES/archive/refs/tags/1.3.0.zip",
+    "downloadUrl": "https://github.com/maserlib/ExPRES/archive/refs/tags/1.4.0.zip",
     "issueTracker": "https://github.com/maserlib/ExPRES/issues",
     "name": "ExPRES",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "identifier": "10.5281/zenodo.4280546",
     "description": "Exoplanetary and Planetary Radio Emission Simulator",
     "applicationCategory": "Astronomy",
-    "releaseNotes": "Add the wave propagation mode (LO or RX) as an (optional) input. Default value is RX.\n",
+    "releaseNotes": "Add the possibility for users to provide magnetic field and density models.\n",
     "funding": "EPN-2024-RI (https://doi.org/10.3030/871149)",
     "developmentStatus": "active",
     "isPartOf": "https://maser.lesia.obspm.fr",
     "referencePublication": "https://doi.org/10.1051/0004-6361/201935161",
     "readme": "https://expres.readthedocs.io/en/latest/",
-    "softwareVersion": "1.3.0",
+    "softwareVersion": "1.4.0",
     "keywords": [
         "radio astronomy; planetary radio emissions; exoplanets; planetary magnetospheres"
     ],
@@ -27,7 +27,7 @@
         "IDL"
     ],
     "relatedLink": [
-        "https://voparis-ns.obspm.fr/maser/expres/v1.3/schema#",
+        "https://voparis-ns.obspm.fr/maser/expres/v1.4/schema#",
         "https://maser.lesia.obspm.fr/task-2-modeling-tools/expres/?lang=en",
         "https://voparis-uws-maser.obspm.fr/client/",
         "http://ascl.net/1902.009",
@@ -42,7 +42,7 @@
             "email": "corentin.louis@obspm.fr",
             "affiliation": {
                 "@type": "Organization",
-                "name": "DIAS, Dublin, Ireland; Observatoire de Paris, France"
+                "name": "LIRA, Observatoire de Paris, Université PSL, Sorbonne Université, Université Paris Cité, CY Cergy Paris Université, CNRS, 92190 Meudon, France"
             }
         },
         {
@@ -64,7 +64,7 @@
             "email": "baptiste.cecconi@obspm.fr",
             "affiliation": {
                 "@type": "Organization",
-                "name": "Observatoire de Paris, France"
+                "name": "LIRA, Observatoire de Paris, Université PSL, Sorbonne Université, Université Paris Cité, CY Cergy Paris Université, CNRS, 92190 Meudon, France"
             }
         },
         {
@@ -75,7 +75,7 @@
             "email": "philippe.zarka@obspm.fr",
             "affiliation": {
                 "@type": "Organization",
-                "name": "CNRS, Observatoire de Paris, France"
+                "name": "LIRA, Observatoire de Paris, Université PSL, Sorbonne Université, Université Paris Cité, CY Cergy Paris Université, CNRS, 92190 Meudon, France"
             }
         },
         {
@@ -86,7 +86,7 @@
             "email": "laurent.lamy@obspm.fr",
             "affiliation": {
                 "@type": "Organization",
-                "name": "Observatoire de Paris, France"
+                "name": "LIRA, Observatoire de Paris, Université PSL, Sorbonne Université, Université Paris Cité, CY Cergy Paris Université, CNRS, 92190 Meudon, France"
             }
         },
         {
@@ -108,7 +108,7 @@
             "email": "alan.loh@obspm.fr",
             "affiliation": {
                 "@type": "Organization",
-                "name": "Observatoire de Paris, France"
+                "name": "LIRA, Observatoire de Paris, Université PSL, Sorbonne Université, Université Paris Cité, CY Cergy Paris Université, CNRS, 92190 Meudon, France"
             }
         }
     ],
@@ -121,7 +121,7 @@
             "email": "corentin.louis@obspm.fr",
             "affiliation": {
                 "@type": "Organization",
-                "name": "Observatoire de Paris, France"
+                "name": "LIRA, Observatoire de Paris, Université PSL, Sorbonne Université, Université Paris Cité, CY Cergy Paris Université, CNRS, 92190 Meudon, France"
             }
         }
     ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,9 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# References
+bibtex_bibfiles = ['refs.bib']
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,12 +6,11 @@
 Welcome to ExPRES' documentation!
 ==================================
 
-ExPRES (Exoplanetary and Planetary Radio Emission Simulator) is a versatile tool that computes the observation
-opportunities of planetary radio emissions, based on the radio source beaming patterns and the observer's location.
+ExPRES (Exoplanetary and Planetary Radio Emission Simulator) is a versatile tool that computes the observation opportunities of planetary, exoplanetary or stellar radio emissions, based on the radio source beaming patterns and the observer's location.
 
 ExPRES is an open source software (available under MIT license). It is maintained on
-`GitHub <https://github.com/maserlib/ExPRES>`_ and it is citable using its `DOI:10.5281/zenodo.4292002
-<https://doi.org/10.5281/zenodo.4292002>`_. The code is described in details in a paper published in Astronomy &
+`GitHub <https://github.com/maserlib/ExPRES>`_ and it is citable using its `DOI:10.5281/zenodo.4280546
+<https://doi.org/10.5281/zenodo.4280546>`_. The code is described in details in a paper published in Astronomy &
 Astrophyics :cite:`Louis:2019`.
 
 ExPRES is part of the `MASER <https://maser.lesia.obspm.fr>`_ (Measuring Analyzing & Simulating Emissions in Radio

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -277,3 +277,29 @@ year = {2019}
     lead angles}},
 	year = 2023,
 }
+
+
+@article{HZ11,
+	adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+	adsurl = {http://adsabs.harvard.edu/abs/2011A%26A...531A..29H},
+	author = {{Hess}, S.~L.~G. and {Zarka}, P.},
+	date-added = {2022-07-26 18:06:29 +0100},
+	date-modified = {2022-07-26 18:06:29 +0100},
+	doi = {10.1051/0004-6361/201116510},
+	eid = {A29},
+	journal = {Astronomy \& Astrophysics},
+	keywords = {planet-star interactions, planets and satellites: aurorae, radio continuum: planetary systems},
+	month = jul,
+	pages = {A29},
+	title = {{Modeling the radio signature of the orbital parameters, rotation, and magnetic field of exoplanets}},
+	volume = 531,
+	year = 2011,
+	bdsk-url-1 = {https://doi.org/10.1051/0004-6361/201116510}}
+
+@article{Z24,
+	author = {{Zarka}, P. and {Louis}, C.~K. and {Zhang}, J. and {Tian}, H. and {Morin}, J. and {Gao}, Y.},
+	doi = {tbd},
+	journal = {Astronomy \& Astrophysics},
+	title = {{Location and energy of electrons producing the radio bursts from AD Leo observed by FAST in December 2021}},
+	date = 2024
+}

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,5 +1,5 @@
 @article{doi:10.1029/97JA03689,
-    author = {Hinson, David P. and Twicken, Joseph D. and Karayel, E. Tuna},
+    author = {Hinson, D.~P. and Twicken, J.~D. and Karayel, E.~T.},
     title = {Jupiter's ionosphere: New results from Voyager 2 radio occultation measurements},
     journal = {Journal of Geophysical Research: Space Physics},
     volume = {103},
@@ -10,7 +10,7 @@
 }
 
 @article{doi:10.1029/93JA02908,
-    author = {Bagenal, Fran},
+    author = {Bagenal, F.},
     title = {Empirical model of the Io plasma torus: Voyager measurements},
     journal = {Journal of Geophysical Research: Space Physics},
     volume = {99},
@@ -21,9 +21,9 @@
 }
 
 @article{And12,
-    author = {Anderson, Brian J. and Johnson, Catherine L. and Korth, Haje and Winslow, Reka M. and Borovsky,
-        Joseph E. and Purucker, Michael E. and Slavin, James A. and Solomon, Sean C. and Zuber, Maria T. and McNutt Jr.,
-        Ralph L.},
+    author = {Anderson, B.~J. and Johnson, C.~L. and Korth, H. and Winslow, R.~M. and Borovsky,
+        J.~ E. and Purucker, M.~E. and Slavin, J.~A. and Solomon, S.~C. and Zuber, M.~T. and McNutt Jr.,
+        R.~L.},
     title = {Low-degree structure in Mercury's planetary magnetic field},
     journal = {Journal of Geophysical Research: Planets},
     volume = {117},
@@ -153,7 +153,7 @@
 
 
 @article{Louis:2019,
-author = {Louis, C K and Hess, S L G and Cecconi, B and Zarka, P and Lamy, L and Aicardi, S and Loh, A},
+author = {Louis, C.~ K. and Hess, S.~L.~G. and Cecconi, B. and Zarka, P. and Lamy, L. and Aicardi, S. and Loh, A.},
 title = {{ExPRES: an Exoplanetary and Planetary Radio Emissions Simulator}},
 journal = {Astronomy and Astrophysics},
 year = {2019},
@@ -164,7 +164,7 @@ doi = {10.1051/0004-6361/201935161}
 
 
 @article{wu_SSR_85,
-author = {Wu, Chi-Wei},
+author = {Wu, C.-W.},
 title = {{Kinetic cyclotron and synchroton Maser instabilities: Radio emission processes by direct amplification
     of radiation}},
 journal = {Space Sci. Rev.},
@@ -174,7 +174,7 @@ pages = {215-298}
 }
 
 @article{hess_GRL_08,
-author = {Hess, SLG and Cecconi, B and Zarka, Philippe},
+author = {Hess, S.~L.~G. and Cecconi, B. and Zarka, P.},
 title = {{Modeling of Io-Jupiter Decameter Arcs, Emission Beaming and Energy Source}},
 journal = {Geophys. Res. Lett.},
 year = {2008},
@@ -183,7 +183,7 @@ number = {L13107},
 }
 
 @article{Louis:2017bz,
-author = {Louis, C K and Lamy, L and Zarka, P and Cecconi, B and Hess, S L G},
+author = {Louis, C.~K. and Lamy, L. and Zarka, P. and Cecconi, B. and Hess, S.~L.~G.},
 title = {{Detection of Jupiter decametric emissions controlled by Europa and Ganymede with Voyager/PRA
 and Cassini/RPWS}},
 journal = {J. geophys. Res. Space Physics},
@@ -194,8 +194,8 @@ month = sep
 }
 
 @article{Louis:2017dl,
-author = {Louis, C K and Lamy, L and Zarka, P and Cecconi, B and Imai, M and Kurth, W S and Hospodarsky, G
-    and Hess, S L G and Bonnin, X and Bolton, S J and Connerney, J E P and Levin, S M},
+author = {Louis, C.~K. and Lamy, L. and Zarka, P. and Cecconi, B. and Imai, M. and Kurth, W.~S. and Hospodarsky, G.
+    and Hess, S.~L.~G. and Bonnin, X. and Bolton, S.~J. and Connerney, J.~E.~P. and Levin, S.~M.},
 title = {{Io-Jupiter decametric arcs observed by Juno/Waves compared to ExPRES simulations}},
 journal = {Geophys. Res. Lett.},
 year = {2017},
@@ -222,7 +222,7 @@ pages = {208-217},
 year = {2017},
 issn = {0019-1035},
 doi = {10.1016/j.icarus.2017.01.009},
-author = {B. Bonfond and D. Grodent and S.V. Badman and J. Saur and J.-C. Gérard and A. Radioti},
+author = {Bonfond, B. and Grodent, D. and Badman, S.V. and Saur, J. and Gérard, J.-C. and Radioti, A.},
 }
 
 
@@ -282,7 +282,7 @@ year = {2019}
 @article{HZ11,
 	adsnote = {Provided by the SAO/NASA Astrophysics Data System},
 	adsurl = {http://adsabs.harvard.edu/abs/2011A%26A...531A..29H},
-	author = {{Hess}, S.~L.~G. and {Zarka}, P.},
+	author = {Hess, S.~L.~G. and Zarka, P.},
 	date-added = {2022-07-26 18:06:29 +0100},
 	date-modified = {2022-07-26 18:06:29 +0100},
 	doi = {10.1051/0004-6361/201116510},
@@ -296,10 +296,22 @@ year = {2019}
 	year = 2011,
 	bdsk-url-1 = {https://doi.org/10.1051/0004-6361/201116510}}
 
-@article{Z24,
-	author = {{Zarka}, P. and {Louis}, C.~K. and {Zhang}, J. and {Tian}, H. and {Morin}, J. and {Gao}, Y.},
-	doi = {tbd},
-	journal = {Astronomy \& Astrophysics},
-	title = {{Location and energy of electrons producing the radio bursts from AD Leo observed by FAST in December 2021}},
-	date = 2024
+@ARTICLE{Z24,
+       author = {Zarka, P. and Louis, C.~K. and Zhang, J. and Tian, H. and Morin, J. and Gao, Y.},
+        title = "{Location and energy of electrons producing the radio bursts from AD Leo observed by FAST in December 2021}",
+      journal = {\aap},
+     keywords = {radiation mechanisms: non-thermal, stars: atmospheres, stars: magnetic field, stars: individual: ADLeo, radio continuum: stars, Astrophysics - Solar and Stellar Astrophysics, Astrophysics - High Energy Astrophysical Phenomena},
+         year = 2025,
+        month = mar,
+       volume = {695},
+          eid = {A95},
+        pages = {A95},
+          doi = {10.1051/0004-6361/202450950},
+archivePrefix = {arXiv},
+       eprint = {2501.16180},
+ primaryClass = {astro-ph.SR},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025A&A...695A..95Z},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
+

--- a/docs/usage/advanced.rst
+++ b/docs/usage/advanced.rst
@@ -559,7 +559,7 @@ Output Configuration
 
 Dynamic Spectrum Output
 .......................
-Dynamic Spectra ouput setup:
+PDF output setup:
 
 - ``INTENSITY``: Flag to ouput 'Intensity' plots (``true`` or ``false``)
 - ``POLAR``: Flag to ouput 'Polar' plots (``true`` or ``false``)
@@ -573,7 +573,12 @@ Dynamic Spectra ouput setup:
 - ``KHZ``: Flag for spectral axis output in kHz (``true`` or ``false``, default is MHz)
 - ``LOG``: Flag for spectral axis output in log scale (``true`` or ``false``)
 - ``PDF``: Flag for PDF file output (``true`` or ``false``)
-- ``CDF``: Configuration of CDF file output
+
+
+CDF output setup:
+
+- ``CDF``: Configuration of CDF file output:
+
    - ``THETA``: Flag for THETA parameter output in the CDF file (``true`` or ``false``)
    - ``FP``: Flag for FP parameter output in the CDF file (``true`` or ``false``)
    - ``FC``: Flag for FC parameter output in the CDF file (``true`` or ``false``)
@@ -586,6 +591,11 @@ Dynamic Spectra ouput setup:
    - ``CML``: Flag for CML parameter output in the CDF file (``true`` or ``false``)
    - ``SRCPOS``: Flag for SRCPOS parameter output in the CDF file (``true`` or ``false``)
    - ``SRCVIS``: Flag for SRCVIS parameter output in the CDF file (``true`` or ``false``)
+
+Note that a CDF file is always produced (output by default), and that it will always contain at least the ``POLARISATION`` variable (regardless of the value of the other flags, even if they are all set to ``false``).
+
+IDL saveset output setup:
+
 - ``INFOS``: IDL Saveset output (for debugging) (``true`` or ``false``)
 
 .. _M2D:

--- a/docs/usage/advanced.rst
+++ b/docs/usage/advanced.rst
@@ -414,6 +414,7 @@ therefore :math:`T = \sqrt{\frac{a^{3} * 4 * \pi^{2}}{G * M_{\textrm{Io}}}}*\fra
 
 - ``INIT_AX``: The reference longitude (in degrees)
 - ``MAG``: The internal body magnetic field model (see the :ref:`Magnetic Field Model<MFL>` section below)
+- ``MAG_FOLDER``: if ``MAG: auto``, this is the folder name containing the csv files with user defined magnetic field model of the body (see the :ref:`Magnetic Field Model<MFL>` section below)
 - ``MOTION``: Flag to indicate if the current body is moving in the simulation frame (must be ``false`` for the central
   body)
 - ``PARENT``: Named body, around which the current body is orbiting (must be one of the defined bodies, and must be
@@ -770,6 +771,9 @@ diameter of 5.91 Jovian Radii (orbit of Io) and a torus scale-height of 1 Jovian
 Magnetic Field Models
 ---------------------
 
+Pre-defined Models
++++++++++++
+
 The detailed magnetic field models available for ExPRES are listed in the `LESIA_mag
 <https://gitlab.obspm.fr/maser/lesia-mag/lesia-mag_idl>`_ repository. We recall below the list of models and the
 related references.
@@ -781,7 +785,11 @@ related references.
 +=========+============+===============+============+===============+========================+
 | Mercury | A12        | :cite:`And12` |                            | ``A12``                |
 +---------+------------+---------------+------------+---------------+------------------------+
+| Earth   | IGRF2000   |               |                            | ``IGRF2000``           |
++---------+------------+---------------+------------+---------------+------------------------+
 | Jupiter | JRM33      | :cite:`CTO21` | CON20      | :cite:`CON20` | ``JRM33``              |
+|         +------------+---------------+            +               +------------------------+
+|         | JRM09      | :cite:`CKO18  |            |               | ``JRM09_CS2020``       |
 |         +------------+---------------+------------+---------------+------------------------+
 |         | ISaAC      | :cite:`HBZ11` | CAN81      | :cite:`CAN81` | ``ISaAC+Connerney CS`` |
 |         +------------+---------------+            |               +------------------------+
@@ -803,4 +811,32 @@ related references.
 |         +------------+---------------+----------------------------+------------------------+
 |         | Q3         | :cite:`CAN87` |                            | ``Q3``                 |
 +---------+------------+---------------+----------------------------+------------------------+
+|Exoplanet| TDS axi    | :cite:`HZ11`  |                            | ``TDS_axi``            |
+|         +------------+---------------+----------------------------+------------------------+
+|         | TDS        | :cite:`HZ11`  |                            | ``TDS``                |
++---------+------------+---------------+----------------------------+------------------------+
+| Tau Boo | Tau Boo    |               |                            | ``Tau_Boo_ab_axi``     |
++---------+------------+---------------+----------------------------+------------------------+
+| AD Leo  |ADLeo 262G  |  :cite:`Z24`  |                            | ``ADLeonis_262G``      |
+|         +------------+---------------+----------------------------+------------------------+
+|         |ADLeo 300G  |  :cite:`Z24`  |                            | ``ADLeonis_300G``      |
+|         +------------+---------------+----------------------------+------------------------+
+|         |ADLeo 441G  |  :cite:`Z24`  |                            | ``ADLeonis_441G``      |
+|         +------------+---------------+----------------------------+------------------------+
+|         |ADLeo 460G  |  :cite:`Z24`  |                            | ``ADLeonis_460G``      |
++---------+------------+---------------+----------------------------+------------------------+
+|Proxima Centauri axi  |               |                            |``proxima_centauri_axi``|
+|Proxima Centauri      |               |                            |``proxima_centauri``    |
++---------+------------+---------------+----------------------------+------------------------+
 
+User-defined Model
++++++++++++
+
+If the user want to use it's own pre-defined model, it is needed to set ``MAG: 'auto'``. The user will have to give the path to the folder that contains the user-defined magnetic field lines, using the option ``MAG_FOLDER: 'path/to/the/directory/containing/the/Magnetic_field_lines/files`` (without a '/' at the end of the path)
+The files need to be in csv (comma separated values) format, and contain (see example below) for each point along the magnetic field lines the cartesian coordinates (X, Y, Z, in main body radius units) and the corresponding magnetic field values (BX, BY, BZ, in Gauss units), and optionnaly the value of the density (in :math:`cm^{-3}` units). The header needs to contain at least a line that informs if the field line is connected to the main body (True or False), and the name of the variables (needs to be X, Y, Z, BX, BY, BZ, Rho).
+
+.. code-block::
+
+  #Field line is connected to star: True
+  #X [Rs], Y [Rs], Z [Rs], BX [G], BY [G], BZ [G], Rho [g/cm3]
+  8.859999656677246094e+00,  0.000000000000000000e+00,  0.000000000000000000e+00,  1.744556119298172961e-02,  -4.976430410837964996e-04,  -8.696679184620229822e-04, 12.541234207203594e+03

--- a/docs/usage/advanced.rst
+++ b/docs/usage/advanced.rst
@@ -45,12 +45,7 @@ definition.
   models. The radio emission observable when the observer is located within the radio source beaming pattern.
   (Figure adapted from C. Louis, PhD Dissertation, 2018)
 
-All spatial parameters of the simulation configuration (distances, radii, lengths...) must be defined in the same units
-as that of provided *central body* radius. Hence, setting the central body radius to *1* implies that all other spatial
-parameters are provided in units of the central body planetary radii. On the contrary, providing the radius of the
-central body in km implies that all other spatial parameters must be also provided in km. The recommended convention
-is to provide all spatial parameters in units of the *central body* radius. This convention is followed in the examples
-provided below. **Note that if you use the ``OBSERVER`` ``TYPE``: ``Pre-Defined`` with ``EPHEM``: *file name* you will need to provide the *central body* radius in km (hence  the same applies to all other spatial parameters).**
+All spatial parameters of the simulation configuration (distances, radii, lengths...) must be defined in the same units as that of provided *central body* radius. The two options are *km* or *central body planetary radii*. Hence, providing the radius of the central body in km implies that all other spatial parameters must be also provided in km. On the contrary, setting the central body radius to *1* implies that all other spatial parameters are provided in units of the central body planetary radii. This second convention is followed in the examples provided below. **Note that if you use the ``OBSERVER`` ``TYPE``: ``Pre-Defined`` with ``EPHEM``: *file name* you will need to provide the *central body* radius in km (hence  the same applies to all other spatial parameters).**
 
 The file output file names are built by ExPRES, using a set up configuration parameters. The general scheme is:
 ``expres_{OBS}_{BODY}_{SRC}_{MAG}_{SRC_PROP}_{DATE}_v{VERS}.json``. The parts of the template are explained in the table
@@ -80,7 +75,7 @@ Simulation Setup
 ----------------
 
 The simulation setup is configured via an ExPRES configuration file (in *JSON* format), following the `ExPRES
-JSON-Schema v1.3 <https://voparis-ns.pages.obspm.fr/maser/expres/v1.3/schema#>`_.
+JSON-Schema v1.4 <https://voparis-ns.obspm.fr/maser/expres/v1.4/schema>`_.
 
 
 
@@ -774,68 +769,72 @@ Magnetic Field Models
 Pre-defined Models
 +++++++++++
 
-The detailed magnetic field models available for ExPRES are listed in the `LESIA_mag
-<https://gitlab.obspm.fr/maser/lesia-mag/lesia-mag_idl>`_ repository. We recall below the list of models and the
-related references.
+The detailed magnetic field models available for ExPRES are listed in the `LESIA_mag <https://gitlab.obspm.fr/maser/lesia-mag/lesia-mag_idl>`_ repository. We recall below the list of models and the related references.
 
-+---------+----------------------------+----------------------------+------------------------+
-| Planet  | Magnetic Field Model       | Current Sheet Model        | ``BODY.MAG`` Value     |
-|         +------------+---------------+------------+---------------+                        |
-|         | Short Name | Reference     | Model Name | Reference     |                        |
-+=========+============+===============+============+===============+========================+
-| Mercury | A12        | :cite:`And12` |                            | ``A12``                |
-+---------+------------+---------------+------------+---------------+------------------------+
-| Earth   | IGRF2000   |               |                            | ``IGRF2000``           |
-+---------+------------+---------------+------------+---------------+------------------------+
-| Jupiter | JRM33      | :cite:`CTO21` | CON20      | :cite:`CON20` | ``JRM33``              |
-|         +------------+---------------+            +               +------------------------+
-|         | JRM09      | :cite:`CKO18  |            |               | ``JRM09_CS2020``       |
-|         +------------+---------------+------------+---------------+------------------------+
-|         | ISaAC      | :cite:`HBZ11` | CAN81      | :cite:`CAN81` | ``ISaAC+Connerney CS`` |
-|         +------------+---------------+            |               +------------------------+
-|         | JRM09      | :cite:`CKO18` |            |               | ``JRM09+Connerney CS`` |
-|         +------------+---------------+            |               +------------------------+
-|         | O6         | :cite:`C1992` |            |               | ``O6+Connerney CS``    |
-|         +------------+---------------+            |               +------------------------+
-|         | VIP4       | :cite:`CAN98` |            |               | ``VIP4+Connerney CS``  |
-|         +------------+---------------+            |               +------------------------+
-|         | VIPAL      | :cite:`HBB17` |            |               | ``VIPAL+Connerney CS`` |
-|         +------------+---------------+            |               +------------------------+
-|         | VIT4       | :cite:`C2007` |            |               | ``VIT4+Connerney CS``  |
-+---------+------------+---------------+------------+---------------+------------------------+
-| Saturn  | SPV        | :cite:`DS90`  |                            | ``SPV``                |
-|         +------------+---------------+----------------------------+------------------------+
-|         | Z3         | :cite:`CAN84` |                            | ``Z3``                 |
-+---------+------------+---------------+----------------------------+------------------------+
-| Uranus  | AH5        | :cite:`H2009` |                            | ``AH5``                |
-|         +------------+---------------+----------------------------+------------------------+
-|         | Q3         | :cite:`CAN87` |                            | ``Q3``                 |
-+---------+------------+---------------+----------------------------+------------------------+
-|Exoplanet| TDS axi    | :cite:`HZ11`  |                            | ``TDS_axi``            |
-|         +------------+---------------+----------------------------+------------------------+
-|         | TDS        | :cite:`HZ11`  |                            | ``TDS``                |
-+---------+------------+---------------+----------------------------+------------------------+
-| Tau Boo | Tau Boo    |               |                            | ``Tau_Boo_ab_axi``     |
-+---------+------------+---------------+----------------------------+------------------------+
-| AD Leo  |ADLeo 262G  |  :cite:`Z24`  |                            | ``ADLeonis_262G``      |
-|         +------------+---------------+----------------------------+------------------------+
-|         |ADLeo 300G  |  :cite:`Z24`  |                            | ``ADLeonis_300G``      |
-|         +------------+---------------+----------------------------+------------------------+
-|         |ADLeo 441G  |  :cite:`Z24`  |                            | ``ADLeonis_441G``      |
-|         +------------+---------------+----------------------------+------------------------+
-|         |ADLeo 460G  |  :cite:`Z24`  |                            | ``ADLeonis_460G``      |
-+---------+------------+---------------+----------------------------+------------------------+
-|Proxima Centauri axi  |               |                            |``proxima_centauri_axi``|
-|Proxima Centauri      |               |                            |``proxima_centauri``    |
-+---------+------------+---------------+----------------------------+------------------------+
++---------+-----------------------------+----------------------------+------------------------+
+| Planet  | Magnetic Field Model        | Current Sheet Model        | ``BODY.MAG`` Value     |
+|         +-------------+---------------+------------+---------------+                        |
+|         | Short Name  | Reference     | Model Name | Reference     |                        |
++=========+=============+===============+============+===============+========================+
+| Mercury | A12         | :cite:`And12` |                            | ``A12``                |
++---------+-------------+---------------+------------+---------------+------------------------+
+| Earth   | IGRF2000    |               |                            | ``IGRF2000``           |
++---------+-------------+---------------+------------+---------------+------------------------+
+| Jupiter | JRM33       | :cite:`CTO21` | CON20      | :cite:`CON20` | ``JRM33``              |
+|         +-------------+---------------+            +               +------------------------+
+|         | JRM09       | :cite:`CKO18  |            |               | ``JRM09_CS2020``       |
+|         +-------------+---------------+------------+---------------+------------------------+
+|         | ISaAC       | :cite:`HBZ11` | CAN81      | :cite:`CAN81` | ``ISaAC+Connerney CS`` |
+|         +-------------+---------------+            |               +------------------------+
+|         | JRM09       | :cite:`CKO18` |            |               | ``JRM09+Connerney CS`` |
+|         +-------------+---------------+            |               +------------------------+
+|         | O6          | :cite:`C1992` |            |               | ``O6+Connerney CS``    |
+|         +-------------+---------------+            |               +------------------------+
+|         | VIP4        | :cite:`CAN98` |            |               | ``VIP4+Connerney CS``  |
+|         +-------------+---------------+            |               +------------------------+
+|         | VIPAL       | :cite:`HBB17` |            |               | ``VIPAL+Connerney CS`` |
+|         +-------------+---------------+            |               +------------------------+
+|         | VIT4        | :cite:`C2007` |            |               | ``VIT4+Connerney CS``  |
++---------+-------------+---------------+------------+---------------+------------------------+
+| Saturn  | SPV         | :cite:`DS90`  |                            | ``SPV``                |
+|         +-------------+---------------+----------------------------+------------------------+
+|         | Z3          | :cite:`CAN84` |                            | ``Z3``                 |
++---------+-------------+---------------+----------------------------+------------------------+
+| Uranus  | AH5         | :cite:`H2009` |                            | ``AH5``                |
+|         +-------------+---------------+----------------------------+------------------------+
+|         | Q3          | :cite:`CAN87` |                            | ``Q3``                 |
++---------+-------------+---------------+----------------------------+------------------------+
+|Exoplanet| TDS axi     | :cite:`HZ11`  |                            | ``TDS_axi``            |
+|         +-------------+---------------+----------------------------+------------------------+
+|         | TDS         | :cite:`HZ11`  |                            | ``TDS``                |
++---------+-------------+---------------+----------------------------+------------------------+
+| Tau Boo | Tau Boo     |               |                            | ``Tau_Boo_ab_axi``     |
++---------+-------------+---------------+----------------------------+------------------------+
+| AD Leo  |ADLeo 262G   |  :cite:`Z24`  |                            | ``ADLeonis_262G``      |
+|         +-------------+---------------+----------------------------+------------------------+
+|         |ADLeo 300G   |  :cite:`Z24`  |                            | ``ADLeonis_300G``      |
+|         +-------------+---------------+----------------------------+------------------------+
+|         |ADLeo 441G   |  :cite:`Z24`  |                            | ``ADLeonis_441G``      |
+|         +-------------+---------------+----------------------------+------------------------+
+|         |ADLeo 460G   |  :cite:`Z24`  |                            | ``ADLeonis_460G``      |
++---------+-------------+---------------+----------------------------+------------------------+
+|Proxima  | PC          |               |                            |``proxima_centauri``    |
+|Centauri +-------------+---------------+----------------------------+------------------------+
+|         | PC axi      |               |                            |``proxima_centauri_axi``|
++---------+-------------+---------------+----------------------------+------------------------+
+
+__ https://maser.obspm.fr/support/expres/mfl/A12_lsh/
+__ https://maser.obspm.fr/support/expres/mfl/IGRF2000_lsh/
+
 
 User-defined Model
 +++++++++++
 
-If the user want to use it's own pre-defined model, it is needed to set ``MAG: 'auto'``. The user will have to give the path to the folder that contains the user-defined magnetic field lines, using the option ``MAG_FOLDER: 'path/to/the/directory/containing/the/Magnetic_field_lines/files`` (without a '/' at the end of the path)
+If users want to use their own pre-defined magnetic field model, and optionnaly density model, it is needed to set ``MAG: 'auto'``. Users will have to give the path to the folder that contains the user-defined magnetic field lines, using the option ``MAG_FOLDER: 'path/to/the/directory/containing/the/Magnetic_field_lines/files`` (without a '/' at the end of the path). It is necessary to have one file per longitude with a 1° step.
 The files need to be in csv (comma separated values) format, and contain (see example below) for each point along the magnetic field lines the cartesian coordinates (X, Y, Z, in main body radius units) and the corresponding magnetic field values (BX, BY, BZ, in Gauss units), and optionnaly the value of the density (in :math:`cm^{-3}` units). The header needs to contain at least a line that informs if the field line is connected to the main body (True or False), and the name of the variables (needs to be X, Y, Z, BX, BY, BZ, Rho).
 
 .. code-block::
+  :caption: Example of the first 3 lines of a user-defined csv file for a magnetic field and density model
 
   #Field line is connected to star: True
   #X [Rs], Y [Rs], Z [Rs], BX [G], BY [G], BZ [G], Rho [g/cm3]

--- a/docs/usage/advanced.rst
+++ b/docs/usage/advanced.rst
@@ -403,7 +403,7 @@ Celestial body definitions include the following keywords:
 
 - ``ON``: Flag to activate the current body (``true`` or ``false``)
 - ``NAME``: The name of the current body (must be unique in the configuration file)
-- ``RADIUS``: The radius of the current body (in consistent units throughout the configuration file)
+- ``RADIUS``: The radius of the current body (in consistent units throughout the configuration file, either in km or in planetary radii)
 - ``PERIOD``: The sidereal rotation period of the current body (in minutes)
 - ``FLAT``: The polar flatening ratio of the current body.
 - ``ORB_PER``: The orbital period according to 3rd Kepler's law at 1 radius (in minutes) 
@@ -418,8 +418,8 @@ therefore :math:`T = \sqrt{\frac{a^{3} * 4 * \pi^{2}}{G * M_{\textrm{Io}}}}*\fra
   body)
 - ``PARENT``: Named body, around which the current body is orbiting (must be one of the defined bodies, and must be
   empty for the central body)
-- ``SEMI_MAJ``: The semi-major axis orbital parameter of the current body (must be 0 for the central body)
-- ``SEMI_MIN``: The semi-minor axis orbital parameter of the current body (must be 0 for the central body)
+- ``SEMI_MAJ``: The semi-major axis orbital parameter of the current body (must be 0 for the central body). Same units as central body radius, *i.e.* in km or planetary radii
+- ``SEMI_MIN``: The semi-minor axis orbital parameter of the current body (must be 0 for the central body). Same units as central body radius, *i.e.* in km or planetary radii
 - ``DECLINATION``: The declination orbital parameter of the current body (must be 0 for the central body)
 - ``APO_LONG``: The apoapsis Longitude parameter of the current body (must be 0 for the central body)
 - ``INCLINATION``: The inclination orbital parameter of the current body (must be 0 for the central body)
@@ -478,9 +478,9 @@ Radio Source Configuration
 - ``LAG_MODEL``: Model of the lead angle for the Io active flux tube; choices are: ``hess2011`` :cite:`HBZ11`,
   ``bonfond2009`` :cite:`bonfond_2009_jgr`, ``bonfond2017`` :cite:`bonfond_2017_icarus`, ``hinton2019``
   :cite:`hinton_2019_jgr`, ``Hue2023`` :cite:`Hue2023`.
-- ``LAT``: If ``Fixed in latitude``: Latitude in degree; else: apex distance in planetary radii.
+- ``LAT``: If ``Fixed in latitude``: Latitude in degree; else: apex distance in planetary radii. **NOT in km**
 - ``SUB``: The subcorotation rate of the source (0 = no corotation)
-- ``AURORA_ALT``: The altitude of the aurora (in planetary radii)
+- ``AURORA_ALT``: The altitude of the aurora (same units as central body radius, *i.e.* in km or planetary radii)
 - ``SAT``: The name of the satellite when ``attached to a satellite`` is selected
 - ``NORTH``: Flag to activate the Northern hemisphere source (exclusive with ``SOUTH`` item)
 - ``SOUTH``: Flag to activate the Southern hemisphere source (exclusive with ``NORTH`` item)
@@ -598,7 +598,7 @@ Dynamic Spectra ouput setup:
 .......................
 - ``ON``: Flag to activate Movie2D generation (``true`` or ``false``)
 - ``SUBCYCLE``: Subsampling rate of movie images (1=all temporal steps)
-- ``RANGE``: Size of Field of view (in central body planetary radii)
+- ``RANGE``: Size of Field of view (in central body planetary radii, **NOT in km**)
 
 .. _M3D:
 
@@ -606,9 +606,9 @@ Dynamic Spectra ouput setup:
 ...............
 - ``ON`` Flag to activate Movie3D generation (``true`` or ``false``)
 - ``SUBCYCLE``: Subsampling rate of movie images (1=all temporal steps)
-- ``XRANGE``: Plotting Range in X axis (in central planet radius units)
-- ``YRANGE``: Plotting Range in Y axis (in central planet radius units)
-- ``ZRANGE``: Plotting Range in Z axis (in central planet radius units)
+- ``XRANGE``: Plotting Range in X axis (in central planet radius units, **NOT in km**)
+- ``YRANGE``: Plotting Range in Y axis (in central planet radius units, **NOT in km**)
+- ``ZRANGE``: Plotting Range in Z axis (in central planet radius units, **NOT in km**)
 - ``OBS``: Flag to activate plotting the location of the observer
 - ``TRAJ``: Flag to activate plotting the trajectories of the objects
 
@@ -631,8 +631,8 @@ Plasma density model definitions include the following keywords:
 - ``NAME``: The name of the density model (must be present, not empty and unique in the configuration file).
 - ``TYPE``: The type of the density model, with the allowed values: ``Ionospheric``, ``Stellar``, ``Disk``, ``Torus``.
 - ``RHO0``: Definition depends on density model type (see below).
-- ``SCALE``: Definition depends on density model type (see below).
-- ``PERP``: Definition depends on density model type (see below).
+- ``SCALE``: Definition depends on density model type (see below). Same units as central body radius need no be used, *i.e.* in km or planetary radii
+- ``PERP``: Definition depends on density model type (see below). Same units as central body radius need no be used, *i.e.* in km or planetary radii
 
 Ionospheric Model
 +++++++++++++++++
@@ -650,13 +650,13 @@ where:
 +================+=========================================+============================+===============+
 | :math:`\rho_0` | Reference plasma number density         | :math:`\textrm{cm}^{-3}`   | ``RHO0``      |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`r`      | Radial distance                         | :math:`R_p`                |               |
+| :math:`r`      | Radial distance                         | :math:`R_p` or :math:`km`  |               |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`r_{ref}`| Reference radial distance on ellipsoid  | :math:`R_p`                |               |
+| :math:`r_{ref}`| Reference radial distance on ellipsoid  | :math:`R_p` or :math:`km`  |               |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`h_0`    | Peak density altitude above 1 bar level | :math:`R_p`                | ``PERP``      |
+| :math:`h_0`    | Peak density altitude above 1 bar level | :math:`R_p` or :math:`km`  | ``PERP``      |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`H`      | Scale-height                            | :math:`R_p`                | ``SCALE``     |
+| :math:`H`      | Scale-height                            | :math:`R_p` or :math:`km`  | ``SCALE``     |
 +----------------+-----------------------------------------+----------------------------+---------------+
 
 The :math:`r_{ref}` is computed by ExPRES using the ellipsoid flattening parameter (``FLAT`` keyword in ``BODY``
@@ -694,7 +694,7 @@ where:
 +================+=========================================+============================+===============+
 | :math:`\rho_0` | Reference plasma number density         | :math:`\textrm{cm}^{-3}`   | ``RHO0``      |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`r`      | Radial distance                         | :math:`R_p`                |               |
+| :math:`r`      | Radial distance                         | :math:`R_p` or :math:`km`  |               |
 +----------------+-----------------------------------------+----------------------------+---------------+
 
 **Note:** Configuration keywords ``SCALE`` and ``PERP`` are not used for this model.
@@ -715,13 +715,13 @@ where:
 +================+=========================================+============================+===============+
 | :math:`\rho_0` | Reference plasma number density         | :math:`\textrm{cm}^{-3}`   | ``RHO0``      |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`r`      | Equatorial radial distance              | :math:`R_p`                |               |
+| :math:`r`      | Equatorial radial distance              | :math:`R_p` or :math:`km`  |              |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`z`      | Altitude above equator                  | :math:`R_p`                |               |
+| :math:`z`      | Altitude above equator                  | :math:`R_p` or :math:`km`  |               |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`H_r`    | Equatorial radial scale-height          | :math:`R_p`                | ``PERP``      |
+| :math:`H_r`    | Equatorial radial scale-height          | :math:`R_p` or :math:`km`  | ``PERP``      |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`H_z`    | Vertical scale-height                   | :math:`R_p`                | ``SCALE``     |
+| :math:`H_z`    | Vertical scale-height                   | :math:`R_p` or :math:`km`  | ``SCALE``     |
 +----------------+-----------------------------------------+----------------------------+---------------+
 
 Torus Model
@@ -740,13 +740,13 @@ where:
 +================+=========================================+============================+===============+
 | :math:`\rho_0` | Reference plasma number density         | :math:`\textrm{cm}^{-3}`   | ``RHO0``      |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`r`      | Equatorial radial distance              | :math:`R_p`                |               |
+| :math:`r`      | Equatorial radial distance              | :math:`R_p` or :math:`km`  |               |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`z`      | Altitude above equator                  | :math:`R_p`                |               |
+| :math:`z`      | Altitude above equator                  | :math:`R_p` or :math:`km`  |               |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`r_0`    | Torus center equatorial diameter        | :math:`R_p`                | ``PERP``      |
+| :math:`r_0`    | Torus center equatorial diameter        | :math:`R_p` or :math:`km`  | ``PERP``      |
 +----------------+-----------------------------------------+----------------------------+---------------+
-| :math:`H`      | Torus scale-height                      | :math:`R_p`                | ``SCALE``     |
+| :math:`H`      | Torus scale-height                      | :math:`R_p` or :math:`km`  | ``SCALE``     |
 +----------------+-----------------------------------------+----------------------------+---------------+
 
 **Example:** We define the Io torus, with a peak reference density of :math:`2000\,\textrm{cm}^{-3}`, an equatorial

--- a/docs/usage/advanced.rst
+++ b/docs/usage/advanced.rst
@@ -50,7 +50,7 @@ as that of provided *central body* radius. Hence, setting the central body radiu
 parameters are provided in units of the central body planetary radii. On the contrary, providing the radius of the
 central body in km implies that all other spatial parameters must be also provided in km. The recommended convention
 is to provide all spatial parameters in units of the *central body* radius. This convention is followed in the examples
-provided below.
+provided below. **Note that if you use the ``OBSERVER`` ``TYPE``: ``Pre-Defined`` with ``EPHEM``: *file name* you will need to provide the *central body* radius in km (hence  the same applies to all other spatial parameters).**
 
 The file output file names are built by ExPRES, using a set up configuration parameters. The general scheme is:
 ``expres_{OBS}_{BODY}_{SRC}_{MAG}_{SRC_PROP}_{DATE}_v{VERS}.json``. The parts of the template are explained in the table

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -176,7 +176,7 @@ if tag_names(*obj,/str) eq 'BODY' then begin
 endif
 
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
-print, (*obj).trajectory_xyz
+print, *(*obj).trajectory_xyz
 traj_rtp=xyz_to_rtp(traj_xyz)
 (*obj).trajectory_rtp=PTR_NEW(traj_rtp)
 

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -175,13 +175,6 @@ if tag_names(*obj,/str) eq 'BODY' then begin
 	(*obj).lct=PTR_NEW(l)
 endif
 
-print, (*obj).traj_file
-print, (*obj).motion
-print,'traj_xyz:'
-print,traj_xyz
-print,'pxyz:'
-print,pxyz
-
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
 traj_rtp=xyz_to_rtp(traj_xyz)
 (*obj).trajectory_rtp=PTR_NEW(traj_rtp)

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -176,7 +176,10 @@ if tag_names(*obj,/str) eq 'BODY' then begin
 endif
 
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
-print, *(*obj).trajectory_xyz
+print,'traj_xyz:'
+print, traj_xyz
+print, 'pxyz:'
+print, pxyz
 traj_rtp=xyz_to_rtp(traj_xyz)
 (*obj).trajectory_rtp=PTR_NEW(traj_rtp)
 

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -145,7 +145,7 @@ endif else begin
 	y = (*(obj)).semi_minor_axis(*)*sin(alpha(*))
 	z = fltarr(ns)
 
-	print,c, x, y
+	print,alpha,(*(obj)).semi_major_axis(*), *(obj)).semi_minor_axis(*)
 
 	r=sqrt(x^2+y^2+z^2)
 	rp=shift(r,-1)

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -145,7 +145,7 @@ endif else begin
 	y = (*(obj)).semi_minor_axis(*)*sin(alpha(*))
 	z = fltarr(ns)
 
-	print,alpha,(*(obj)).semi_major_axis(*), *(obj)).semi_minor_axis(*)
+	print,alpha,(*(obj)).semi_major_axis, (*(obj)).semi_minor_axis
 
 	r=sqrt(x^2+y^2+z^2)
 	rp=shift(r,-1)

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -177,10 +177,10 @@ endif
 
 print, (*obj).traj_file
 print, (*obj).motion
-print,'rtp:'
-print,rtp
-print,'xyz:'
-print,xyz
+print,'traj_xyz:'
+print,traj_xyz
+print,'pxyz:'
+print,pxyz
 
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
 traj_rtp=xyz_to_rtp(traj_xyz)

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -138,12 +138,14 @@ if (*obj).traj_file eq '' then begin
 endif else begin
 
 
-;*********** on a a chaque pas de t la valeur de la distance à Jupiter, la longitude et l inclinaison
+;*********** At eacg t step we have the value of the distance, longitude and inclination to the central body
 	alpha=(*(obj)).initial_phase*!dtor
 	c = sqrt((*(obj)).semi_major_axis(*)^2-(*(obj)).semi_minor_axis(*)^2)
 	x = (*(obj)).semi_major_axis(*)*cos(alpha(*))+c
 	y = (*(obj)).semi_minor_axis(*)*sin(alpha(*))
 	z = fltarr(ns)
+
+	print,c, x, y
 
 	r=sqrt(x^2+y^2+z^2)
 	rp=shift(r,-1)

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -69,14 +69,11 @@ if (*obj).traj_file eq '' then begin
 	if (*obj).motion eq 0 then begin
 		rtp=rtp(*,0)
 		rtp[1]=!pi*0.5-(*(obj)).apoapsis_declination*!dtor
-print,'rtp:'
-print,rtp
+  
 		xyz=fltarr(3)
 		xyz(2)=rtp(0)*cos(rtp(1))
 		xyz(0)=rtp(0)*sin(rtp(1))*cos(rtp(2))
 		xyz(1)=rtp(0)*sin(rtp(1))*sin(rtp(2))
-print,'xyz:'
-print,xyz
 		traj_rtp[*,*]=rebin(rtp,3,ns)
 		traj_xyz[*,*]=rebin(xyz,3,ns)
 	endif else begin
@@ -177,12 +174,15 @@ if tag_names(*obj,/str) eq 'BODY' then begin
 
 	(*obj).lct=PTR_NEW(l)
 endif
+print, (*obj).traj_file
+print, (*obj).motion
+print,'rtp:'
+print,rtp
+print,'xyz:'
+print,xyz
+
 
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
-print,'traj_xyz:'
-print, traj_xyz
-print, 'pxyz:'
-print, pxyz
 traj_rtp=xyz_to_rtp(traj_xyz)
 (*obj).trajectory_rtp=PTR_NEW(traj_rtp)
 

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -176,6 +176,7 @@ if tag_names(*obj,/str) eq 'BODY' then begin
 endif
 
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
+print, (*obj).trajectory_xyz
 traj_rtp=xyz_to_rtp(traj_xyz)
 (*obj).trajectory_rtp=PTR_NEW(traj_rtp)
 

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -175,6 +175,13 @@ if tag_names(*obj,/str) eq 'BODY' then begin
 	(*obj).lct=PTR_NEW(l)
 endif
 
+print, (*obj).traj_file
+print, (*obj).motion
+print,'rtp:'
+print,rtp
+print,'xyz:'
+print,xyz
+
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
 traj_rtp=xyz_to_rtp(traj_xyz)
 (*obj).trajectory_rtp=PTR_NEW(traj_rtp)

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -69,11 +69,14 @@ if (*obj).traj_file eq '' then begin
 	if (*obj).motion eq 0 then begin
 		rtp=rtp(*,0)
 		rtp[1]=!pi*0.5-(*(obj)).apoapsis_declination*!dtor
-
+print,'rtp:'
+print,rtp
 		xyz=fltarr(3)
 		xyz(2)=rtp(0)*cos(rtp(1))
 		xyz(0)=rtp(0)*sin(rtp(1))*cos(rtp(2))
 		xyz(1)=rtp(0)*sin(rtp(1))*sin(rtp(2))
+print,'xyz:'
+print,xyz
 		traj_rtp[*,*]=rebin(rtp,3,ns)
 		traj_xyz[*,*]=rebin(xyz,3,ns)
 	endif else begin

--- a/src/orb_body.pro
+++ b/src/orb_body.pro
@@ -145,8 +145,6 @@ endif else begin
 	y = (*(obj)).semi_minor_axis(*)*sin(alpha(*))
 	z = fltarr(ns)
 
-	print,alpha,(*(obj)).semi_major_axis, (*(obj)).semi_minor_axis
-
 	r=sqrt(x^2+y^2+z^2)
 	rp=shift(r,-1)
 	corec=2.*abs(rp-r)/(rp+r)*360./2./!pi+1.
@@ -176,13 +174,6 @@ if tag_names(*obj,/str) eq 'BODY' then begin
 
 	(*obj).lct=PTR_NEW(l)
 endif
-print, (*obj).traj_file
-print, (*obj).motion
-print,'rtp:'
-print,rtp
-print,'xyz:'
-print,xyz
-
 
 (*obj).trajectory_xyz=PTR_NEW(traj_xyz+pxyz)
 traj_rtp=xyz_to_rtp(traj_xyz)

--- a/src/read_ephem_obs.pro
+++ b/src/read_ephem_obs.pro
@@ -25,12 +25,12 @@ if tmp[-1] eq 'csv' then begin
 		date=strmid(result.field01[0:n-1],0,4)+strmid(result.field01[0:n-1],5,2)+strmid(result.field01[0:n-1],8,2)+strmid(result.field01[0:n-1],11,2)+strmid(result.field01[0:n-1],14,2)+strmid(result.field01[0:n-1],17,2)
 		longitude=(360+(-1.)*result.field02[0:n-1]+360.) mod 360d
 		lat=result.field03[0:n-1]
-		distance=result.field04[0:n-1]/radius_parent
+		distance=result.field04[0:n-1]/71492
 	endif else begin
 		date=strmid(result.field1[0:n-1],0,4)+strmid(result.field1[0:n-1],5,2)+strmid(result.field1[0:n-1],8,2)+strmid(result.field1[0:n-1],11,2)+strmid(result.field1[0:n-1],14,2)+strmid(result.field1[0:n-1],17,2)
 		longitude=(360+(-1.)*result.field2[0:n-1]+360.) mod 360d
 		lat=result.field3[0:n-1]
-		distance=result.field4[0:n-1]/radius_parent
+		distance=result.field4[0:n-1]/71492
 	endelse
 endif
 

--- a/src/read_ephem_obs.pro
+++ b/src/read_ephem_obs.pro
@@ -25,12 +25,12 @@ if tmp[-1] eq 'csv' then begin
 		date=strmid(result.field01[0:n-1],0,4)+strmid(result.field01[0:n-1],5,2)+strmid(result.field01[0:n-1],8,2)+strmid(result.field01[0:n-1],11,2)+strmid(result.field01[0:n-1],14,2)+strmid(result.field01[0:n-1],17,2)
 		longitude=(360+(-1.)*result.field02[0:n-1]+360.) mod 360d
 		lat=result.field03[0:n-1]
-		distance=result.field04[0:n-1]/71492
+		distance=result.field04[0:n-1]/radius_parent
 	endif else begin
 		date=strmid(result.field1[0:n-1],0,4)+strmid(result.field1[0:n-1],5,2)+strmid(result.field1[0:n-1],8,2)+strmid(result.field1[0:n-1],11,2)+strmid(result.field1[0:n-1],14,2)+strmid(result.field1[0:n-1],17,2)
 		longitude=(360+(-1.)*result.field2[0:n-1]+360.) mod 360d
 		lat=result.field3[0:n-1]
-		distance=result.field4[0:n-1]/71492
+		distance=result.field4[0:n-1]/radius_parent
 	endelse
 endif
 

--- a/src/read_ephem_obs.pro
+++ b/src/read_ephem_obs.pro
@@ -2,19 +2,28 @@ PRO read_ephem_obs,ephem,radius_parent,time0,time,observer,longitude,distance,la
 
 radius_parent = DOUBLE(radius_parent)
 tmp=(STRSPLIT(ephem,'.',/EXTRACT))
+print,"starting read_ephem_obs routine"
 if tmp[-1] eq 'csv' then begin
 
 	result=read_csv(ephem,n_table_header=14,table_header=head)
 	if head[-2] ne 'State Vector Results' then result=read_csv(ephem,n_table_header=16,table_header=head)
 	if n_tags(result) ge 10 then begin
+ 		print,"n_tag ge 10"
+   		print,n_elements(result.field01)
 		if n_elements(result.field01) lt 7 then goto, erreur
 	endif else begin
+ 		print,"n_tag lt 10"
+   		print,n_elements(result.field1)
 		if n_elements(result.field1) lt 7 then goto, erreur
 	endelse
 	
 	if n_tags(result) ge 10 then begin
+ 		print,"n_tag ge 10"
+   		print,n_elements(where(result.field04 ne 0))
 		n=n_elements(where(result.field04 ne 0))
 	endif else begin
+ 		print,"n_tag lt 10"
+   		print,n_elements(where(result.field4 ne 0))
 		n=n_elements(where(result.field4 ne 0))
 	endelse
 	Date=strarr(n)

--- a/src/read_ephem_obs.pro
+++ b/src/read_ephem_obs.pro
@@ -2,28 +2,19 @@ PRO read_ephem_obs,ephem,radius_parent,time0,time,observer,longitude,distance,la
 
 radius_parent = DOUBLE(radius_parent)
 tmp=(STRSPLIT(ephem,'.',/EXTRACT))
-print,"starting read_ephem_obs routine"
 if tmp[-1] eq 'csv' then begin
 
 	result=read_csv(ephem,n_table_header=14,table_header=head)
 	if head[-2] ne 'State Vector Results' then result=read_csv(ephem,n_table_header=16,table_header=head)
 	if n_tags(result) ge 10 then begin
- 		print,"n_tag ge 10"
-   		print,n_elements(result.field01)
 		if n_elements(result.field01) lt 7 then goto, erreur
 	endif else begin
- 		print,"n_tag lt 10"
-   		print,n_elements(result.field1)
 		if n_elements(result.field1) lt 7 then goto, erreur
 	endelse
 	
 	if n_tags(result) ge 10 then begin
- 		print,"n_tag ge 10"
-   		print,n_elements(where(result.field04 ne 0))
 		n=n_elements(where(result.field04 ne 0))
 	endif else begin
- 		print,"n_tag lt 10"
-   		print,n_elements(where(result.field4 ne 0))
 		n=n_elements(where(result.field4 ne 0))
 	endelse
 	Date=strarr(n)

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1280,7 +1280,7 @@ endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
   endfor
   read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],radius_parent,time0,time,observer,longitude,distance,lat,error
-  print, distance
+
   if error eq 1 then stop,'Check your ephemeris file'
   struct_replace_field,observer,'SMAJ',distance
   struct_replace_field,observer,'SMIN',distance
@@ -1761,7 +1761,10 @@ for i=0,nsrc-1 do begin
 		sc[n].refract=((serpe_save['SOURCE'])[i])['REFRACTION']
 	endif
 endfor
-print, observer.smaj, observer.smin
+print, 'parent_body_radius:'
+print, parent_body_radius:
+print, 'bd[wparent[0]]'
+print, bd[wparent[0]]
 observer.smaj/=parent_body_radius ; So that smaj is in planetary radius for sure, whatever the units used by the users
 observer.smin/=parent_body_radius ; So that smin is in planetary radius for sure, whatever the units used by the users
 bd[wparent[0]].rad/=parent_body_radius  ; So that parent body radius is in planetary radius for sure, whatever the units used by the users

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1243,9 +1243,10 @@ endelse
 ;# first for loop is useful to normalize all distance (observer.smin and observer.smax) by the main body radius
 for i=0,nbody-1 do begin
     if ((serpe_save['BODY'])[i])['ON'] then $
-        if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $
+        if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $ ;# if body.parent == '' (i.e., as no parent) it means it is the central body 
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
 endfor
+print, radius_parent
 
 observer.motion=0b
 observer.predef=0b
@@ -1606,8 +1607,8 @@ for i=0,nbody-1 do begin
 		bd[n].smaj=((serpe_save['BODY'])[i])['SEMI_MAJ']
 		bd[n].smin=((serpe_save['BODY'])[i])['SEMI_MIN']
 
-     		if bd[n].parent eq '' then $ ;# if no parent == central body
-			parent_body_radius = bd[n].rad 
+     		;#if bd[n].parent eq '' then $ ;# if no parent == central body
+		;#	parent_body_radius = bd[n].rad 
    
     		bd[n].decl=((serpe_save['BODY'])[i])['DECLINATION']
 		bd[n].alg=((serpe_save['BODY'])[i])['APO_LONG']
@@ -1624,9 +1625,10 @@ for i=0,nbody-1 do begin
       ; # updating the date to take into account the light travel time
       ; # The longitude of a secondary body (a moon) is taken from the moon pov
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
-	
+	print, observer.smaj[0]
+ 	print, radius_parent
       if observer.motion eq 0 then begin
-        caldat,julday1-(observer.smaj[0]*parent_body_radius/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
+        caldat,julday1-(observer.smaj[0]*radius_parent/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
       endif else begin
         stop,"The ExPRES team has to configure the light travel time correction for the case where the observer is an orbiter..."
       endelse
@@ -1673,13 +1675,13 @@ endfor
 n=0
 nd=0
 for i=0,n_elements(bd)-1 do begin; So that every "distance" values are in planetary radius for sure, including parent body radius, whatever the units used by the users
-	bd[n].smaj/=parent_body_radius
-	bd[n].smin/=parent_body_radius
- 	bd[n].rad/=parent_body_radius
+	bd[n].smaj/=radius_parent
+	bd[n].smin/=radius_parent
+ 	bd[n].rad/=radius_parent
 endfor
 for i=0,n_elements(ds)-1 do begin
-	ds[nd].height/=parent_body_radius
-	ds[nd].perp/=parent_body_radius
+	ds[nd].height/=radius_parent
+	ds[nd].perp/=radius_parent
 endfor
 
 ; ***** loading SOURCE section *****

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1605,24 +1605,13 @@ for i=0,nbody-1 do begin
 		bd[n].parent=((serpe_save['BODY'])[i])['PARENT']
 		bd[n].smaj=((serpe_save['BODY'])[i])['SEMI_MAJ']
 		bd[n].smin=((serpe_save['BODY'])[i])['SEMI_MIN']
-    	
-        	wparent = where(bd.name eq bd[n].parent)
-		print, bd.name
-   		print, wparent
-     		print, wparent[0]
-	 	if wparent ne -1 then begin
-   			help, bd[wparent[0]]
-      			parent_body_radius = bd[wparent[0]].rad 
+
+     		if bd[n].parent eq '' then begin ;# if no parent == central body
+			parent_body_radius = bd[n].rad 
 			print, 'parent_body_radius:'
    			print, parent_body_radius
       		endif
-      		print, bd[n].parent 
-    		if bd[n].parent ne '' then begin
-      			bd[n].rad=bd[n].rad/parent_body_radius
-      			bd[n].smaj=bd[n].smaj/parent_body_radius
-      			bd[n].smin=bd[n].smin/parent_body_radius
-    		endif
-		bd[n].decl=((serpe_save['BODY'])[i])['DECLINATION']
+    		bd[n].decl=((serpe_save['BODY'])[i])['DECLINATION']
 		bd[n].alg=((serpe_save['BODY'])[i])['APO_LONG']
 		bd[n].incl=((serpe_save['BODY'])[i])['INCLINATION']
 
@@ -1682,6 +1671,17 @@ for i=0,nbody-1 do begin
 		endif
 	endfor
 endfor
+
+print, 'parent_body_radius:'
+print, parent_body_radius
+n=0
+for i=0,n_elements(bd)-1 do begin; So that parent body radius is in planetary radius for sure, whatever the units used by the users
+	bd[n].rad/=parent_body_radius
+	bd[n].smaj/parent_body_radius
+	bd[n].smin/=parent_body_radius
+ 	bd[n].rad/=parent_body_radius
+endfor
+
 
 ; ***** loading SOURCE section *****
 sc=[src]
@@ -1770,13 +1770,6 @@ for i=0,nsrc-1 do begin
 		sc[n].refract=((serpe_save['SOURCE'])[i])['REFRACTION']
 	endif
 endfor
-print, 'parent_body_radius:'
-print, parent_body_radius
-print, 'bd[wparent[0]]'
-print, bd[wparent[0]]
-observer.smaj/=parent_body_radius ; So that smaj is in planetary radius for sure, whatever the units used by the users
-observer.smin/=parent_body_radius ; So that smin is in planetary radius for sure, whatever the units used by the users
-bd[wparent[0]].rad/=parent_body_radius  ; So that parent body radius is in planetary radius for sure, whatever the units used by the users
 
 ; ***** building SERPE objects *****
 parameters = build_serpe_obj(version,adresse_mfl,file_name,nbody,ndens,nsrc,ticket,time,freq,observer,bd,ds,sc,spdyn,cdf,mov2d,mov3d)

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1608,7 +1608,7 @@ for i=0,nbody-1 do begin
 
      		if bd[n].parent eq '' then $ ;# if no parent == central body
 			parent_body_radius = bd[n].rad 
-      		endif
+   
     		bd[n].decl=((serpe_save['BODY'])[i])['DECLINATION']
 		bd[n].alg=((serpe_save['BODY'])[i])['APO_LONG']
 		bd[n].incl=((serpe_save['BODY'])[i])['INCLINATION']

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1279,7 +1279,7 @@ endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
         if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
   endfor
-  read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],radius_parent,time0,time,observer,longitude,distance,lat,error
+  read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],1,time0,time,observer,longitude,distance,lat,error ;# radius_parent is set to 1 here, because we do not want to normalize the distance yet. It will be down for all 'distance' value at the end of this loop
 
   if error eq 1 then stop,'Check your ephemeris file'
   struct_replace_field,observer,'SMAJ',distance
@@ -1672,7 +1672,7 @@ endfor
 
 n=0
 nd=0
-for i=0,n_elements(bd)-1 do begin; So that parent body radius is in planetary radius for sure, whatever the units used by the users
+for i=0,n_elements(bd)-1 do begin; So that every "distance" values are in planetary radius for sure, including parent body radius, whatever the units used by the users
 	bd[n].smaj/=parent_body_radius
 	bd[n].smin/=parent_body_radius
  	bd[n].rad/=parent_body_radius

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1280,6 +1280,7 @@ endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
   endfor
   read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],radius_parent,time0,time,observer,longitude,distance,lat,error
+  print, distance
   if error eq 1 then stop,'Check your ephemeris file'
   struct_replace_field,observer,'SMAJ',distance
   struct_replace_field,observer,'SMIN',distance

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1334,15 +1334,15 @@ if (serpe_save['OBSERVER'])['EPHEM'] eq '' then begin
   				
   		endelse
   		; enregistrement des donnees lues
-  		observer.smaj=distance[0]
-  	  observer.smin=distance[0]
+  		observer.smaj=distance[0] ; Will be divided by bd[wparent[0]].rad at the end, when body entry will have been read
+  	  observer.smin=distance[0] ; Will be divided by bd[wparent[0]].rad at the end, when body entry will have been read
   	  observer.phs=-longitude[0]
   		observer.decl=lat[0]
   		
   		
   	endif else begin	; sinon enregistre donnees entrees par utilisateur
-  		observer.smaj=float((serpe_save['OBSERVER'])['FIXE_DIST'])
-  	  	observer.smin=float((serpe_save['OBSERVER'])['FIXE_DIST'])
+  		observer.smaj=float((serpe_save['OBSERVER'])['FIXE_DIST']) ; Will be divided by bd[wparent[0]].rad at the end, when body entry will have been read
+  	  	observer.smin=float((serpe_save['OBSERVER'])['FIXE_DIST']) ; Will be divided by bd[wparent[0]].rad at the end, when body entry will have been read
   		observer.phs=-float((serpe_save['OBSERVER'])['FIXE_SUBL'])
   		observer.decl=float((serpe_save['OBSERVER'])['FIXE_DECL'])
   	endelse
@@ -1469,8 +1469,8 @@ endif
 ; ********* ********	
 	
 if observer.motion then begin
-	observer.smaj=(serpe_save['OBSERVER'])['SEMI_MAJ']
-	observer.smin=(serpe_save['OBSERVER'])['SEMI_MIN']
+	observer.smaj=(serpe_save['OBSERVER'])['SEMI_MAJ'] ; Will be divided by bd[wparent[0]].rad at the end, when body entry will have been read
+	observer.smin=(serpe_save['OBSERVER'])['SEMI_MIN'] ; Will be divided by bd[wparent[0]].rad at the end, when body entry will have been read
 	observer.alg=(serpe_save['OBSERVER'])['SUBL']
 	observer.decl=(serpe_save['OBSERVER'])['DECL']
 	observer.phs=(serpe_save['OBSERVER'])['PHASE']
@@ -1625,14 +1625,9 @@ for i=0,nbody-1 do begin
       ; # updating the date to take into account the light travel time
       ; # The longitude of a secondary body (a moon) is taken from the moon pov
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
-
-      case ((serpe_save['BODY'])[i])['PARENT'] of 
-        'Jupiter': Rayon=71492.00
-        'Uranus': Rayon=25559.00
-        'Saturn': Rayon=60268.00
-      endcase
+	
       if observer.motion eq 0 then begin
-        caldat,julday1-(observer.smaj[0]*Rayon/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
+        caldat,julday1-(observer.smaj[0]/bd[wparent[0]].rad/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
       endif else begin
         stop,"The ExPRES team has to configure the light travel time correction for the case where the observer is an orbiter..."
       endelse
@@ -1763,8 +1758,9 @@ for i=0,nsrc-1 do begin
 		sc[n].refract=((serpe_save['SOURCE'])[i])['REFRACTION']
 	endif
 endfor
-
-bd[wparent[0]].rad/=bd[wparent[0]].rad
+observer.smaj/=bd[wparent[0]].rad ; So that smaj is in planetary radius for sure, whatever the units used by the users
+observer.smin/=bd[wparent[0]].rad ; So that smin is in planetary radius for sure, whatever the units used by the users
+bd[wparent[0]].rad/=bd[wparent[0]].rad  ; So that parent body radius is in planetary radius for sure, whatever the units used by the users
 
 ; ***** building SERPE objects *****
 parameters = build_serpe_obj(version,adresse_mfl,file_name,nbody,ndens,nsrc,ticket,time,freq,observer,bd,ds,sc,spdyn,cdf,mov2d,mov3d)

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1629,7 +1629,7 @@ for i=0,nbody-1 do begin
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
 	
       if observer.motion eq 0 then begin
-        caldat,julday1-(observer.smaj[0]/bd[wparent[0]].rad/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
+        caldat,julday1-(observer.smaj[0]/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
       endif else begin
         stop,"The ExPRES team has to configure the light travel time correction for the case where the observer is an orbiter..."
       endelse

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1274,12 +1274,15 @@ if (serpe_save['OBSERVER'])['EPHEM'] eq "@wgc" then begin
     endif
 
 endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
+  print((serpe_save['OBSERVER'])['EPHEM'])
   for i=0,nbody-1 do begin
     if ((serpe_save['BODY'])[i])['ON'] then $
         if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
+  print(radius_parent)
   endfor
   read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],radius_parent,time0,time,observer,longitude,distance,lat,error
+  print("reading done")
   if error eq 1 then stop,'Check your ephemeris file'
   struct_replace_field,observer,'SMAJ',distance
   struct_replace_field,observer,'SMIN',distance

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1636,7 +1636,7 @@ for i=0,nbody-1 do begin
 
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
       print,radius_parent
-      if radius_parent eq 1 then
+      if radius_parent eq 1 then $
         stop, "In that case (['BODY']['PHASE'] = 'auto'), you need to have all your distance units defined in km so that the light travel time is correctly taken into account"
       if observer.motion eq 0 then begin
         caldat,julday1-(observer.smaj[0]*radius_parent/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1670,8 +1670,8 @@ for i=0,nbody-1 do begin
 			ds[nd].name=((((serpe_save['BODY'])[i])['DENS'])[l])['NAME']
 			ds[nd].type=((((serpe_save['BODY'])[i])['DENS'])[l])['TYPE']
 			ds[nd].rho0=((((serpe_save['BODY'])[i])['DENS'])[l])['RHO0']
-			ds[nd].height=((((serpe_save['BODY'])[i])['DENS'])[l])['SCALE']
-			ds[nd].perp=((((serpe_save['BODY'])[i])['DENS'])[l])['PERP']
+			ds[nd].height=((((serpe_save['BODY'])[i])['DENS'])[l])['SCALE']/bd[wparent[0]].rad
+			ds[nd].perp=((((serpe_save['BODY'])[i])['DENS'])[l])['PERP']/bd[wparent[0]].rad
 		endif
 	endfor
 endfor

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1677,7 +1677,7 @@ print, parent_body_radius
 n=0
 for i=0,n_elements(bd)-1 do begin; So that parent body radius is in planetary radius for sure, whatever the units used by the users
 	bd[n].rad/=parent_body_radius
-	bd[n].smaj/parent_body_radius
+	bd[n].smaj/=parent_body_radius
 	bd[n].smin/=parent_body_radius
  	bd[n].rad/=parent_body_radius
 endfor

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1672,22 +1672,21 @@ for i=0,nbody-1 do begin
 	endfor
 endfor
 
-n=0
-nd=0
+
 for i=0,n_elements(bd)-1 do begin; So that every "distance" values are in planetary radius for sure, including parent body radius, whatever the units used by the users
-	bd[n].smaj/=radius_parent
-	bd[n].smin/=radius_parent
- 	bd[n].rad/=radius_parent
+ 	bd[i].smaj/=radius_parent
+	bd[i].smin/=radius_parent
+ 	bd[i].rad/=radius_parent
 endfor
 for i=0,n_elements(ds)-1 do begin
-	ds[nd].height/=radius_parent
-	ds[nd].perp/=radius_parent
+	ds[i].height/=radius_parent
+	ds[i].perp/=radius_parent
 endfor
 
 print, 'observer'
 print, observer
 print,'body'
-for i=0,n_elements(bd)-1 do print,bd[i]
+for i=0,n_elements(bd)-1 do help,bd[i]
 
 
 ; ***** loading SOURCE section *****

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1633,10 +1633,24 @@ for i=0,nbody-1 do begin
       ; # The longitude of a secondary body (a moon) is taken from the moon pov
 
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
-      if radius_parent eq 1 then $
-        stop, "In that case (['BODY']['PHASE'] = 'auto'), you need to have all your distance units defined in km so that the light travel time is correctly taken into account"
+      if radius_parent eq 1 then begin
+	    CASE ((serpe_save['BODY'])[i])['PARENT'] OF
+     		'Earth':   radius_parent_fix = 6378.137
+       		'Mars':    radius_parent_fix = 3396.2
+        	'Jupiter': radius_parent_fix = 71492.00
+        	'Saturn':  radius_parent_fix = 60268.00
+	 	'Uranus':  radius_parent_fix = 25559.00
+   		'Neptune':  radius_parent_fix = 24764.00
+        	ELSE: stop, "In that case (['BODY']['PHASE'] = 'auto' and the ((serpe_save['BODY'])[i])['PARENT'] you have chosen), you need to have all your distance units defined in km so that the light travel time is correctly taken into account"
+    	    ENDCASE
+      endif
+      
       if observer.motion eq 0 then begin
-        caldat,julday1-(observer.smaj[0]*radius_parent/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
+          if radius_parent eq 1 then begin
+       	       caldat,julday1-(observer.smaj[0]*radius_parent_fix/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
+          endif else begin
+	      caldat,julday1-(observer.smaj[0]*radius_parent/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
+          endelse
       endif else begin
         stop,"The ExPRES team has to configure the light travel time correction for the case where the observer is an orbiter..."
       endelse

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1666,8 +1666,8 @@ for i=0,nbody-1 do begin
 			ds[nd].name=((((serpe_save['BODY'])[i])['DENS'])[l])['NAME']
 			ds[nd].type=((((serpe_save['BODY'])[i])['DENS'])[l])['TYPE']
 			ds[nd].rho0=((((serpe_save['BODY'])[i])['DENS'])[l])['RHO0']
-			ds[nd].height=((((serpe_save['BODY'])[i])['DENS'])[l])['SCALE']/parent_body_radius
-			ds[nd].perp=((((serpe_save['BODY'])[i])['DENS'])[l])['PERP']/parent_body_radius
+			ds[nd].height=((((serpe_save['BODY'])[i])['DENS'])[l])['SCALE']
+			ds[nd].perp=((((serpe_save['BODY'])[i])['DENS'])[l])['PERP']
 		endif
 	endfor
 endfor
@@ -1675,13 +1675,16 @@ endfor
 print, 'parent_body_radius:'
 print, parent_body_radius
 n=0
+nd=0
 for i=0,n_elements(bd)-1 do begin; So that parent body radius is in planetary radius for sure, whatever the units used by the users
-	bd[n].rad/=parent_body_radius
 	bd[n].smaj/=parent_body_radius
 	bd[n].smin/=parent_body_radius
  	bd[n].rad/=parent_body_radius
 endfor
-
+for i=0,n_elements(ds)-1 do begin
+	ds[nd].height/=parent_body_radius
+	ds[nd].perp/=parent_body_radius
+endfor
 
 ; ***** loading SOURCE section *****
 sc=[src]

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1628,11 +1628,14 @@ for i=0,nbody-1 do begin
 ; si c est le cas, on calcul à partir de la longitude au t=0 de la closest approach la longitude au t=0 de la simulation
 ; si c est pas le cas, alors on fait appelle à MIRIADE pour les éphémérides au t=0 de la simulation
 		if size((((serpe_save['BODY'])[i])['PHASE']),/type) eq 7 then begin									; if phase = "auto"
+  print,size((((serpe_save['BODY'])[i])['PHASE']),/type)
+  print,(((serpe_save['BODY'])[i])['PHASE'])
     	
       ; # updating the date to take into account the light travel time
       ; # The longitude of a secondary body (a moon) is taken from the moon pov
 
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
+      print,radius_parent
       if radius_parent eq 1:
         stop, "In that case (['BODY']['PHASE'] = 'auto'), you need to have all your distance units defined in km so that the light travel time is correctly taken into account"
       if observer.motion eq 0 then begin

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1670,8 +1670,6 @@ for i=0,nbody-1 do begin
 	endfor
 endfor
 
-print, 'parent_body_radius:'
-print, parent_body_radius
 n=0
 nd=0
 for i=0,n_elements(bd)-1 do begin; So that parent body radius is in planetary radius for sure, whatever the units used by the users

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1609,8 +1609,14 @@ for i=0,nbody-1 do begin
         	wparent = where(bd.name eq bd[n].parent)
 		print, bd.name
    		print, wparent
-	 	if wparent ne -1 then $
+     		print, wparent[0]
+	 	if wparent ne -1 then begin
+   			help, bd[wparent[0]]
       			parent_body_radius = bd[wparent[0]].rad 
+			print, 'parent_body_radius:'
+   			print, parent_body_radius
+      		endif
+      		print, bd[n].parent 
     		if bd[n].parent ne '' then begin
       			bd[n].rad=bd[n].rad/parent_body_radius
       			bd[n].smaj=bd[n].smaj/parent_body_radius

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1607,7 +1607,10 @@ for i=0,nbody-1 do begin
 		bd[n].smin=((serpe_save['BODY'])[i])['SEMI_MIN']
     	
         	wparent = where(bd.name eq bd[n].parent)
-      		parent_body_radius = bd[wparent[0]].rad 
+		print, bd.name
+   		print, wparent
+	 	if wparent ne -1 then $
+      			parent_body_radius = bd[wparent[0]].rad 
     		if bd[n].parent ne '' then begin
       			bd[n].rad=bd[n].rad/parent_body_radius
       			bd[n].smaj=bd[n].smaj/parent_body_radius

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1684,6 +1684,12 @@ for i=0,n_elements(ds)-1 do begin
 	ds[nd].perp/=radius_parent
 endfor
 
+print, 'observer'
+print, observer
+print,'body'
+for i=0,n_elements(bd)-1 do print,bd[i]
+
+
 ; ***** loading SOURCE section *****
 sc=[src]
 n=0

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1274,15 +1274,12 @@ if (serpe_save['OBSERVER'])['EPHEM'] eq "@wgc" then begin
     endif
 
 endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
-  print,(serpe_save['OBSERVER'])['EPHEM']
   for i=0,nbody-1 do begin
     if ((serpe_save['BODY'])[i])['ON'] then $
         if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
-  print,radius_parent
   endfor
   read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],radius_parent,time0,time,observer,longitude,distance,lat,error
-  print,"reading done"
   if error eq 1 then stop,'Check your ephemeris file'
   struct_replace_field,observer,'SMAJ',distance
   struct_replace_field,observer,'SMIN',distance

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1636,7 +1636,7 @@ for i=0,nbody-1 do begin
 
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
       print,radius_parent
-      if radius_parent eq 1:
+      if radius_parent eq 1 then
         stop, "In that case (['BODY']['PHASE'] = 'auto'), you need to have all your distance units defined in km so that the light travel time is correctly taken into account"
       if observer.motion eq 0 then begin
         caldat,julday1-(observer.smaj[0]*radius_parent/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1761,6 +1761,7 @@ for i=0,nsrc-1 do begin
 		sc[n].refract=((serpe_save['SOURCE'])[i])['REFRACTION']
 	endif
 endfor
+print, observer.smaj, observer.smin
 observer.smaj/=parent_body_radius ; So that smaj is in planetary radius for sure, whatever the units used by the users
 observer.smin/=parent_body_radius ; So that smin is in planetary radius for sure, whatever the units used by the users
 bd[wparent[0]].rad/=parent_body_radius  ; So that parent body radius is in planetary radius for sure, whatever the units used by the users

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1762,7 +1762,7 @@ for i=0,nsrc-1 do begin
 	endif
 endfor
 print, 'parent_body_radius:'
-print, parent_body_radius:
+print, parent_body_radius
 print, 'bd[wparent[0]]'
 print, bd[wparent[0]]
 observer.smaj/=parent_body_radius ; So that smaj is in planetary radius for sure, whatever the units used by the users

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1628,14 +1628,11 @@ for i=0,nbody-1 do begin
 ; si c est le cas, on calcul à partir de la longitude au t=0 de la closest approach la longitude au t=0 de la simulation
 ; si c est pas le cas, alors on fait appelle à MIRIADE pour les éphémérides au t=0 de la simulation
 		if size((((serpe_save['BODY'])[i])['PHASE']),/type) eq 7 then begin									; if phase = "auto"
-  print,size((((serpe_save['BODY'])[i])['PHASE']),/type)
-  print,(((serpe_save['BODY'])[i])['PHASE'])
     	
       ; # updating the date to take into account the light travel time
       ; # The longitude of a secondary body (a moon) is taken from the moon pov
 
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
-      print,radius_parent
       if radius_parent eq 1 then $
         stop, "In that case (['BODY']['PHASE'] = 'auto'), you need to have all your distance units defined in km so that the light travel time is correctly taken into account"
       if observer.motion eq 0 then begin

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1604,12 +1604,14 @@ for i=0,nbody-1 do begin
 		bd[n].parent=((serpe_save['BODY'])[i])['PARENT']
 		bd[n].smaj=((serpe_save['BODY'])[i])['SEMI_MAJ']
 		bd[n].smin=((serpe_save['BODY'])[i])['SEMI_MIN']
-    if bd[n].parent ne '' then begin
-      wparent = where(bd.name eq bd[n].parent)
-      bd[n].rad=bd[n].rad/bd[wparent[0]].rad
-      bd[n].smaj=bd[n].smaj/bd[wparent[0]].rad
-      bd[n].smin=bd[n].smin/bd[wparent[0]].rad
-    endif
+    	
+        	wparent = where(bd.name eq bd[n].parent)
+      		parent_body_radius = bd[wparent[0]].rad 
+    		if bd[n].parent ne '' then begin
+      			bd[n].rad=bd[n].rad/parent_body_radius
+      			bd[n].smaj=bd[n].smaj/parent_body_radius
+      			bd[n].smin=bd[n].smin/parent_body_radius
+    		endif
 		bd[n].decl=((serpe_save['BODY'])[i])['DECLINATION']
 		bd[n].alg=((serpe_save['BODY'])[i])['APO_LONG']
 		bd[n].incl=((serpe_save['BODY'])[i])['INCLINATION']
@@ -1665,8 +1667,8 @@ for i=0,nbody-1 do begin
 			ds[nd].name=((((serpe_save['BODY'])[i])['DENS'])[l])['NAME']
 			ds[nd].type=((((serpe_save['BODY'])[i])['DENS'])[l])['TYPE']
 			ds[nd].rho0=((((serpe_save['BODY'])[i])['DENS'])[l])['RHO0']
-			ds[nd].height=((((serpe_save['BODY'])[i])['DENS'])[l])['SCALE']/bd[wparent[0]].rad
-			ds[nd].perp=((((serpe_save['BODY'])[i])['DENS'])[l])['PERP']/bd[wparent[0]].rad
+			ds[nd].height=((((serpe_save['BODY'])[i])['DENS'])[l])['SCALE']/parent_body_radius
+			ds[nd].perp=((((serpe_save['BODY'])[i])['DENS'])[l])['PERP']/parent_body_radius
 		endif
 	endfor
 endfor
@@ -1758,9 +1760,9 @@ for i=0,nsrc-1 do begin
 		sc[n].refract=((serpe_save['SOURCE'])[i])['REFRACTION']
 	endif
 endfor
-observer.smaj/=bd[wparent[0]].rad ; So that smaj is in planetary radius for sure, whatever the units used by the users
-observer.smin/=bd[wparent[0]].rad ; So that smin is in planetary radius for sure, whatever the units used by the users
-bd[wparent[0]].rad/=bd[wparent[0]].rad  ; So that parent body radius is in planetary radius for sure, whatever the units used by the users
+observer.smaj/=parent_body_radius ; So that smaj is in planetary radius for sure, whatever the units used by the users
+observer.smin/=parent_body_radius ; So that smin is in planetary radius for sure, whatever the units used by the users
+bd[wparent[0]].rad/=parent_body_radius  ; So that parent body radius is in planetary radius for sure, whatever the units used by the users
 
 ; ***** building SERPE objects *****
 parameters = build_serpe_obj(version,adresse_mfl,file_name,nbody,ndens,nsrc,ticket,time,freq,observer,bd,ds,sc,spdyn,cdf,mov2d,mov3d)

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1246,7 +1246,6 @@ for i=0,nbody-1 do begin
         if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $ ;# if body.parent == '' (i.e., as no parent) it means it is the central body 
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
 endfor
-print, radius_parent
 
 observer.motion=0b
 observer.predef=0b
@@ -1625,8 +1624,6 @@ for i=0,nbody-1 do begin
       ; # updating the date to take into account the light travel time
       ; # The longitude of a secondary body (a moon) is taken from the moon pov
       ; # It's necessary to go back in time, corresponding to the distance main body-observer
-	print, observer.smaj[0]
- 	print, radius_parent
       if observer.motion eq 0 then begin
         caldat,julday1-(observer.smaj[0]*radius_parent/3e5/60./60./24.),M0,D0,Y0,H0,Mi0,S0
       endif else begin
@@ -1682,11 +1679,6 @@ for i=0,n_elements(ds)-1 do begin
 	ds[i].height/=radius_parent
 	ds[i].perp/=radius_parent
 endfor
-
-print, 'observer'
-print, observer
-print,'body'
-for i=0,n_elements(bd)-1 do help,bd[i]
 
 
 ; ***** loading SOURCE section *****

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1274,12 +1274,12 @@ if (serpe_save['OBSERVER'])['EPHEM'] eq "@wgc" then begin
     endif
 
 endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
-  print((serpe_save['OBSERVER'])['EPHEM'])
+  print,(serpe_save['OBSERVER'])['EPHEM']
   for i=0,nbody-1 do begin
     if ((serpe_save['BODY'])[i])['ON'] then $
         if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
-  print(radius_parent)
+  print,radius_parent
   endfor
   read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],radius_parent,time0,time,observer,longitude,distance,lat,error
   print("reading done")

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1606,10 +1606,8 @@ for i=0,nbody-1 do begin
 		bd[n].smaj=((serpe_save['BODY'])[i])['SEMI_MAJ']
 		bd[n].smin=((serpe_save['BODY'])[i])['SEMI_MIN']
 
-     		if bd[n].parent eq '' then begin ;# if no parent == central body
+     		if bd[n].parent eq '' then $ ;# if no parent == central body
 			parent_body_radius = bd[n].rad 
-			print, 'parent_body_radius:'
-   			print, parent_body_radius
       		endif
     		bd[n].decl=((serpe_save['BODY'])[i])['DECLINATION']
 		bd[n].alg=((serpe_save['BODY'])[i])['APO_LONG']

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1282,7 +1282,7 @@ endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
   print,radius_parent
   endfor
   read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],radius_parent,time0,time,observer,longitude,distance,lat,error
-  print("reading done")
+  print,"reading done"
   if error eq 1 then stop,'Check your ephemeris file'
   struct_replace_field,observer,'SMAJ',distance
   struct_replace_field,observer,'SMIN',distance

--- a/src/read_save.pro
+++ b/src/read_save.pro
@@ -1279,6 +1279,7 @@ endif else if (serpe_save['OBSERVER'])['EPHEM'] ne '' then begin
         if ((serpe_save['BODY'])[i])['PARENT'] eq '' then $
             radius_parent = ((serpe_save['BODY'])[i])['RADIUS']
   endfor
+  print,radius_parent
   read_ephem_obs,(serpe_save['OBSERVER'])['EPHEM'],1,time0,time,observer,longitude,distance,lat,error ;# radius_parent is set to 1 here, because we do not want to normalize the distance yet. It will be down for all 'distance' value at the end of this loop
 
   if error eq 1 then stop,'Check your ephemeris file'

--- a/src/serpe_lesia.pro
+++ b/src/serpe_lesia.pro
@@ -114,7 +114,8 @@ STRREPLACE,name_r,'queue', 'on-going'
 comd='mv '+name_rold+' '+name_r
 spawn,comd
 
-version='v13'
+
+version='v14'
 
 adresse_mfl=loadpath('adresse_mfl',parameters)
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -245,7 +245,6 @@ if ((*obj).lagauto eq "on+3") then begin
 	(*((*obj).lg))[0,*,*]=calc_lag((*obj).lagmodel,(*obj).north,(*((*obj).parent)).lg,satellite=(*(*(*obj).parent).parent).name)+3.
 endif
 ;********************************************************
-
 lg=reform((*((*obj).lg))[0,*,*]+(*((*obj).parent)).lg,nlg*nlat)
 lg=(lg+360.) mod 360.
 lg0=fix(lg) & lg1=(lg0+1) mod 360 & c=lg-lg0  & lgc=lg0*0.
@@ -256,13 +255,23 @@ lat=reform((*((*obj).lat))[0,*,*]+(*((*obj).parent)).latitude[lg]-(*((*obj).pare
 
 ; **** Calcul des coefficients d interpolation ***
 coef=fltarr(nlg*nlat,4)
-a=lg-fix(lg)
-b=lat-fix(lat)
+
+if (*(*obj).parent).sat then mfl_auto = (*(*(*(*obj).parent).parent).parent).mfl $
+	else mfl_auto = (*(*(*obj).parent).parent).mfl
+
+if mfl_auto eq 'auto' then begin
+	a = 0
+	b = 0
+endif else begin
+	a=lg-fix(lg)
+	b=lat-fix(lat)
+endelse
 coef[*,0]=(1.-a)*(1.-b)
 coef[*,1]=(1.-a)*b
 coef[*,2]=a*(1.-b)
 coef[*,3]=a*b
 coef=reform(rebin(reform(coef,1,1,nlg,nlat,4),3,parameters.freq.n_freq,nlg,nlat,4),3,parameters.freq.n_freq,nlg*nlat,4)
+
 
 b=fltarr(3,parameters.freq.n_freq,nlg*nlat)		 ;vecteur champ unitaire
 bz=fltarr(3,parameters.freq.n_freq,nlg*nlat)	 ;vecteur direction normale au L-shell
@@ -303,6 +312,7 @@ endif else begin if (*obj).south then begin				; Magnetic south pole
 endif
 endelse
 
+ 
 coef=0b
 
 (*(*obj).fmax)[*,var]=f

--- a/src/src.pro
+++ b/src/src.pro
@@ -313,10 +313,10 @@ coef=0b
 
 ;**** Calculation of the line of sight vector
 ; Vector of the distance between the observer and the source
-print,'x'
-print,x
-print,'xyz_obs'
-print,xyz_obs
+;print,'x'
+;print,x
+;print,'xyz_obs'
+;print,xyz_obs
 x=xyz_obs-x 
 ; *** distance observateur-source ***
 dist=rebin(reform(sqrt(total(x^2,1)),1,parameters.freq.n_freq,nlg*nlat),3,parameters.freq.n_freq,nlg*nlat) 

--- a/src/src.pro
+++ b/src/src.pro
@@ -313,6 +313,10 @@ coef=0b
 
 ;**** Calculation of the line of sight vector
 ; Vector of the distance between the observer and the source
+print,'x'
+print,x
+print,'xyz_obs'
+print,xyz_obs
 x=xyz_obs-x 
 ; *** distance observateur-source ***
 dist=rebin(reform(sqrt(total(x^2,1)),1,parameters.freq.n_freq,nlg*nlat),3,parameters.freq.n_freq,nlg*nlat) 

--- a/src/src.pro
+++ b/src/src.pro
@@ -313,10 +313,6 @@ coef=0b
 
 ;**** Calculation of the line of sight vector
 ; Vector of the distance between the observer and the source
-;print,'x'
-;print,x
-;print,'xyz_obs'
-;print,xyz_obs
 x=xyz_obs-x 
 ; *** distance observateur-source ***
 dist=rebin(reform(sqrt(total(x^2,1)),1,parameters.freq.n_freq,nlg*nlat),3,parameters.freq.n_freq,nlg*nlat) 


### PR DESCRIPTION
- In this version, and based on the work done with A. Strugarek (https://orcid.org/0000-0002-9630-6463), we have added an option so that the user can directly provide as input a magnetic field model and a density model, for each magnetic field line (in steps of 1°). The format is described in the documentation.

- Ephemeris for Juno up to end of Extended Mission (October 10, 2025) have been added

- The code has also been modified so that now the units for radius and distance can be either physical units (km) or in Planetary Radius (needs to be consistent all through the config file).
Note that:
     - if you use the ``OBSERVER``: ``TYPE``: ``Pre-Defined`` with ``OBSERVER``: ``EPHEM``: *file name* you will need to provide the radius and distance values in *km* units
     - If you use ``BODY``: ``PHASE``: "auto" (for body ≠ central body), you will need to provide the radius and distance values in *km* units (because ExPRES will call  the MIRIADE ephemeris system to obtain automatically the ephemeris of this body, and it needs to have the radius of the body in km, as it will need to take into account the light travel time to have the correct ephemeris). A safety has been added for Solar System planets, so it will work even if radius and distance values are given in planetary radii, but we do not recommand it.

